### PR TITLE
Update {epiparameter} usage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Authors@R: c(
     person("Hugo", "Gruson", , "hugo.gruson+R@normalesup.org", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-4094-1476")),
     person("Thibaut", "Jombart", role = "aut"),
+    person("Carmen", "Tamayo", role = "aut"),
     person("data.org", role = "fnd")
   )
 Description: A store of outbreak analytics pipelines using different

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R: c(
     person("Hugo", "Gruson", , "hugo.gruson+R@normalesup.org", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-4094-1476")),
     person("Thibaut", "Jombart", role = "aut"),
-    person("Carmen", "Tamayo", role = "aut"),
+    person("Carmen", "Tamayo", role = "aut", comment = c(ORCID = "0000-0003-4184-2864")),
     person("data.org", role = "fnd")
   )
 Description: A store of outbreak analytics pipelines using different

--- a/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiEstim.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiEstim.Rmd
@@ -16,13 +16,12 @@ library(EpiEstim)
 # Function to process a distrcrete object and output `si_discr` argument for
 # EpiEstim::make_config
 
-wrap_si <- function(x) {
-  stopifnot(inherits(x, "distcrete"))
-  max_x <- x$q(0.999)
-  x <- si$d(seq_len(max_x))
-  x[1] <- 0
-  x <- x / sum(x)
-  x
+wrap_si <- function(si) {
+  domain <- seq(1L, to = si$prob_dist$qf(0.999), by = 1L)
+  pmf <- si$prob_dist$d(domain)
+  pmf[1] <- 0
+  pmf <- pmf / sum(pmf)
+  pmf
 }
 
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiNow2.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiNow2.Rmd
@@ -23,7 +23,8 @@ si_gamma <- epiparameter::extract_param(
   distribution = params$si_dist,
   samples = 1e3
 )
-si_gamma <- epiparameter::gamma_shapescale2meansd(si_gamma[[1]], si_gamma[[2]])
+si_gamma <- epiparameter::convert_params_to_summary_stats(
+  distribution = "gamma", shape = si_gamma[[1]], scale = si_gamma[[2]])
 
 generation_time <- list(
   mean = si_gamma$mean,

--- a/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiNow2.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/EpiNow2.Rmd
@@ -17,8 +17,10 @@ library(EpiNow2)
 # will use for generation_time
 si_gamma <- epiparameter::extract_param(
   type = "range",
-  values = c(median(si$r(1e3)), min(si$r(1e3)), max(si$r(1e3))),
-  distribution = "gamma",
+  values = c(median(si$prob_dist$r(1e3)),
+             min(si$prob_dist$r(1e3)),
+             max(si$prob_dist$r(1e3))),
+  distribution = params$si_dist,
   samples = 1e3
 )
 si_gamma <- epiparameter::gamma_shapescale2meansd(si_gamma[[1]], si_gamma[[2]])

--- a/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/R0.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/R0.Rmd
@@ -13,7 +13,7 @@ library(R0)
 ### Results
 
 ```{r rt-wrappers-prep}
-mGT <- generation.time("empirical", si$d(si_x))
+mGT <- generation.time("empirical", si$prob_dist$d(si_x))
 
 # Helper function to get R0 outputs in a tidy format, compatible with pipelines
 r0_quantiles <- function(Rt) {

--- a/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/i2extras.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/rmdchunks/i2extras.Rmd
@@ -141,7 +141,7 @@ This section contains:
 
 ```{r }
 res_R_wl <- last_trends %>%
-  mutate(R = map(model, epitrix::lm2R0_sample, w = si, 500)) %>%
+  mutate(R = map(model, epitrix::lm2R0_sample, w = si$prob_dist$d(si_x))) %>%
   dplyr::select({{ group_var }}, R) %>%
   unnest(R)
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -400,8 +400,8 @@ si_epidist <- epiparameter::epidist_db(
 
 si_params <- get_parameters(si_epidist)
 si_dist <- family(si_epidist)
-si_mean <- get_parameters(si_epidist)[1]
-si_sd <- get_parameters(si_epidist)[2]
+si_mean <- si_params["mean"]
+si_sd <- si_params["sd"]
 ```
 
 ```{r, eval = !params$use_epiparameter_database}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -79,7 +79,7 @@ renv::use(
   "ellipsis@0.3.2",
   "epiverse-trace/episoap", # nolint
   "epitrix@0.4.0",
-  "epiverse-trace/epiparameter@fd250ce", # nolint 
+  "epiverse-trace/epiparameter@e531c09", # nolint 
   "evaluate@0.23",
   "fansi@1.0.5",
   "farver@2.1.1",

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -20,7 +20,7 @@ params:
     label: "Should the serial interval distribution be extracted directly from the epiparameter package?"
     value: FALSE
   epiparameter_disease: 
-    label: "Name of the pathogen in the epiparameter database if `use_parameter = TRUE`."
+    label: "Name of the disease in the epiparameter database if `use_parameter = TRUE`."
     value: "COVID-19"
   si_mean:
     label: "Mean of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter = TRUE`."

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -391,7 +391,7 @@ discretized Gamma.
 ## Results
 
 ```{r, eval = params$use_epiparameter_database}
-si_epidist <- epiparameter::epidist_db(
+si_epidist <- epidist_db(
   disease =  params$disease_name,
   epi_dist =  "serial_interval",
   single_epidist = TRUE,
@@ -418,7 +418,7 @@ si_epidist <- epidist(
 ```
 
 ```{r}
-si <- epiparameter::discretise(si_epidist)
+si <- discretise(si_epidist)
 si_x <- seq(1L, to = quantile(si, 0.999), by = 1L)
 ```
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -394,7 +394,6 @@ discretized Gamma.
 si_epiparameter <- epiparameter::epidist_db(
   disease =  params$epiparameter_disease,
   epi_dist =  "serial_interval",
-  author = "Nishiura",
   single_epidist = TRUE
 )
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -16,20 +16,20 @@ params:
   r_estim_window:
     label: "Number of days to include to get the latest observed value of Rt."
     value: 21
-  use_epiparameter: 
+  use_epiparameter_database: 
     label: "Should the serial interval distribution be extracted directly from the epiparameter package?"
     value: FALSE
   epiparameter_disease: 
-    label: "Name of the disease in the epiparameter database if `use_parameter = TRUE`."
+    label: "Name of the disease in the epiparameter database if `use_parameter_database = TRUE`."
     value: "COVID-19"
   si_mean:
-    label: "Mean of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter = TRUE`."
+    label: "Mean of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter_database = TRUE`."
     value: 4.2
   si_sd: 
-    label: "Standard deviation of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter = TRUE`."
+    label: "Standard deviation of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter_database = TRUE`."
     value: 4.9
   si_dist: 
-    label: "Choice of probability distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter = TRUE`."
+    label: "Choice of probability distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter_database = TRUE`."
     value: "gamma"
     choices: ["beta", "binom", "cauchy", "chisq", "exp", "f", "gamma", "geom", "hyper", "lnorm", "logis", "nbinom", "norm", "pois", "smirnov", "t", "tukey", "unif", "weibull", "wilcox"]
   data_file: 
@@ -390,7 +390,7 @@ discretized Gamma.
 
 ## Results
 
-```{r, eval = params$use_epiparameter}
+```{r, eval = params$use_epiparameter_database}
 si_epiparameter <- epiparameter::epidist_db(
   disease =  params$epiparameter_disease,
   epi_dist =  "serial_interval",
@@ -403,7 +403,7 @@ si_mean <- si_epiparameter$summary_stats$mean
 si_sd <- si_epiparameter$summary_stats$sd
 ```
 
-```{r, eval = !params$use_epiparameter}
+```{r, eval = !params$use_epiparameter_database}
 si_mean <- params$si_mean
 si_sd <- params$si_sd
 si_dist <- params$si_dist

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -397,7 +397,7 @@ si_epiparameter <- epiparameter::epidist_db(
   single_epidist = TRUE
 )
 
-si_params <- as.list(get_parameters(si_epiparameter))
+si_params <- get_parameters(si_epiparameter)
 si_dist <- family(si_epiparameter)
 si_mean <- si_epiparameter$summary_stats$mean
 si_sd <- si_epiparameter$summary_stats$sd

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -411,7 +411,7 @@ si_mean <- params$si_mean
 si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
-si_params <- epitrix::gamma_mucv2shapescale(mu = si_mean, cv = si_cv)
+si_params <- epiparameter::convert_summary_stats_to_params(distribution = "gamma", mean = si_mean, sd = si_sd) 
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -408,7 +408,6 @@ si_sd <- si_params["sd"]
 si_mean <- params$si_mean
 si_sd <- params$si_sd
 si_dist <- params$si_dist
-si_cv <- si_sd / si_mean
 si_epidist <- epidist(
   disease = params$disease_name,
   epi_dist = "serial_interval",

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -397,10 +397,10 @@ si_epidist <- epiparameter::epidist_db(
   single_epidist = TRUE
 )
 
-si_params <- get_parameters(si_epiparameter)
-si_dist <- family(si_epiparameter)
-si_mean <- si_epiparameter$summary_stats$mean
-si_sd <- si_epiparameter$summary_stats$sd
+si_params <- get_parameters(si_epidist)
+si_dist <- family(si_epidist)
+si_mean <- si_epidist$summary_stats$mean
+si_sd <- si_epidist$summary_stats$sd
 ```
 
 ```{r, eval = !params$use_epiparameter_database}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -409,7 +409,7 @@ si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
 si_params <- epiparameter::convert_summary_stats_to_params(
-  distribution = "gamma", mean = si_mean, sd = si_sd
+  distribution = params$si_dist, mean = si_mean, sd = si_sd
 )
 ```
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -19,9 +19,9 @@ params:
   use_epiparameter: 
     label: "Should the serial interval distribution be extracted directly from the epiparameter package?"
     value: FALSE
-  epiparameter_pathogen: 
+  epiparameter_disease: 
     label: "Name of the pathogen in the epiparameter database if `use_parameter = TRUE`."
-    value: "SARS_CoV_2_wildtype"
+    value: "COVID-19"
   si_mean:
     label: "Mean of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter = TRUE`."
     value: 4.2
@@ -393,14 +393,17 @@ discretized Gamma.
 ## Results
 
 ```{r, eval = params$use_epiparameter}
-si_epiparameter <- epiparameter::epidist(
-  params$epiparameter_pathogen,
-  "serial_interval"
-)
-si_params <- si_epiparameter$param
-si_dist <- si_epiparameter$dist
-si_mean <- si_params[[1]]
-si_sd <- si_params[[2]]
+si_epiparameter <- epiparameter::epidist_db(
+  disease =  params$epiparameter_disease,
+  epi_dist =  "serial_interval",
+  author = "Nishiura",
+  single_epidist = T
+   )
+
+si_params <- as.list(get_parameters(si_epiparameter))
+si_dist <- family(si_epiparameter)
+si_mean <- si_epiparameter$summary_stats$mean
+si_sd <- si_epiparameter$summary_stats$sd
 ```
 
 ```{r, eval = !params$use_epiparameter}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -222,8 +222,6 @@ library(linelist)
 library(janitor)
 library(kableExtra)
 library(incidence2)
-library(distcrete)
-library(epitrix)
 library(grateful)
 library(epiparameter)
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -273,7 +273,7 @@ data_path <- params$data_file
 
 ```{r}
 dat_raw <- data_path %>%
-  rio::import() %>%
+  import() %>%
   tibble() %>%
   # rio (via readxl) tends to use POSIXct for what is encoded as Date in the
   # original data file.

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -397,8 +397,8 @@ si_epiparameter <- epiparameter::epidist_db(
   disease =  params$epiparameter_disease,
   epi_dist =  "serial_interval",
   author = "Nishiura",
-  single_epidist = T
-   )
+  single_epidist = TRUE
+  )
 
 si_params <- as.list(get_parameters(si_epiparameter))
 si_dist <- family(si_epiparameter)

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -19,8 +19,8 @@ params:
   use_epiparameter_database: 
     label: "Should the serial interval distribution be extracted directly from the epiparameter package?"
     value: FALSE
-  epiparameter_disease: 
-    label: "Name of the disease in the epiparameter database if `use_parameter_database = TRUE`."
+  disease_name: 
+    label: "Name of the disease of interest, also used to select diseases in the epiparameter database if `use_parameter_database = TRUE`."
     value: "COVID-19"
   si_mean:
     label: "Mean of the distribution for serial interval if not using value from epiparameter. Ignored if `use_epiparameter_database = TRUE`."
@@ -391,8 +391,8 @@ discretized Gamma.
 ## Results
 
 ```{r, eval = params$use_epiparameter_database}
-si_epiparameter <- epiparameter::epidist_db(
-  disease =  params$epiparameter_disease,
+si_epidist <- epiparameter::epidist_db(
+  disease =  params$disease_name,
   epi_dist =  "serial_interval",
   single_epidist = TRUE
 )

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -79,7 +79,7 @@ renv::use(
   "ellipsis@0.3.2",
   "epiverse-trace/episoap", # nolint
   "epitrix@0.4.0",
-  "epiverse-trace/epiparameter@e531c09", # nolint 
+  "epiverse-trace/epiparameter@328706e", # nolint 
   "evaluate@0.23",
   "fansi@1.0.5",
   "farver@2.1.1",

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -420,7 +420,7 @@ si_epidist <- epidist(
 
 ```{r}
 si <- epiparameter::discretise(si_epidist)
-si_x <- seq(1L, to = si$prob_dist$qf(0.999), by = 1L)
+si_x <- seq(1L, to = quantile(si, 0.999), by = 1L)
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -394,7 +394,8 @@ discretized Gamma.
 si_epidist <- epiparameter::epidist_db(
   disease =  params$disease_name,
   epi_dist =  "serial_interval",
-  single_epidist = TRUE
+  single_epidist = TRUE,
+  subset = is_parameterised
 )
 
 si_params <- get_parameters(si_epidist)

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -414,7 +414,7 @@ si_params <- epiparameter::convert_summary_stats_to_params(
 ```
 
 ```{r}
-si <- epiparameter::discretise(si_epiparameter)
+si <- epiparameter::discretise(si_epidist)
 si_x <- seq(1L, to = si$prob_dist$qf(0.999), by = 1L)
 ```
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -414,8 +414,8 @@ si_epidist <- epidist(
   epi_dist = "serial_interval",
   prob_distribution = params$si_dist,
   summary_stats = create_epidist_summary_stats(mean = params$si_mean,
-                                               sd = params$si_sd),
-  auto_calc_params = TRUE)
+                                               sd = params$si_sd)
+)
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -468,6 +468,6 @@ dat_i_day <- dat_raw %>%
 ```
 
 ```{r}
-grateful::cite_packages(output = "paragraph", out.dir = ".", pkgs = "Session")
+cite_packages(output = "paragraph", out.dir = ".", pkgs = "Session")
 ```
 

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -400,8 +400,8 @@ si_epidist <- epiparameter::epidist_db(
 
 si_params <- get_parameters(si_epidist)
 si_dist <- family(si_epidist)
-si_mean <- si_epidist$summary_stats$mean
-si_sd <- si_epidist$summary_stats$sd
+si_mean <- get_parameters(si_epidist)[1]
+si_sd <- get_parameters(si_epidist)[2]
 ```
 
 ```{r, eval = !params$use_epiparameter_database}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -416,26 +416,13 @@ si_params <- epiparameter::convert_summary_stats_to_params(
 ```
 
 ```{r}
-# do.call() because we want to pass `si_params` names as the name of arguments.
-# This is important if params in si_params are not the first arguments of the
-# q...() function. For example, if a gamma distribution is define by its shape
-# and scale, instead of shape and rate.
-si <- do.call(
-  distcrete,
-  c(
-    list(si_dist,
-      interval = 1,
-      w = 0
-    ),
-    si_params
-  )
-)
-si_x <- seq(1L, to = si$q(0.999), by = 1L)
+si <- epiparameter::discretise(si_epiparameter)
+si_x <- seq(1L, to = si$prob_dist$qf(0.999), by = 1L)
 ```
 
 ```{r}
 ggplot(
-  data.frame(delay = si_x, prob = si$d(si_x)),
+  data.frame(delay = si_x, prob = si$prob_dist$d(si_x)),
   aes(x = delay, y = prob)
 ) +
   geom_col(fill = green_grey) +

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -398,7 +398,7 @@ si_epiparameter <- epiparameter::epidist_db(
   epi_dist =  "serial_interval",
   author = "Nishiura",
   single_epidist = TRUE
-  )
+)
 
 si_params <- as.list(get_parameters(si_epiparameter))
 si_dist <- family(si_epiparameter)

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -411,7 +411,8 @@ si_mean <- params$si_mean
 si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
-si_params <- epiparameter::convert_summary_stats_to_params(distribution = "gamma", mean = si_mean, sd = si_sd) 
+si_params <- epiparameter::convert_summary_stats_to_params(
+  distribution = "gamma", mean = si_mean, sd = si_sd) 
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -409,9 +409,13 @@ si_mean <- params$si_mean
 si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
-si_params <- epiparameter::convert_summary_stats_to_params(
-  distribution = params$si_dist, mean = si_mean, sd = si_sd
-)
+si_epidist <- epidist(
+  disease = params$disease_name,
+  epi_dist = "serial_interval",
+  prob_distribution = params$si_dist,
+  summary_stats = create_epidist_summary_stats(mean = params$si_mean,
+                                               sd = params$si_sd),
+  auto_calc_params = TRUE)
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -412,7 +412,7 @@ si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
 si_params <- epiparameter::convert_summary_stats_to_params(
-  distribution = "gamma", mean = si_mean, sd = si_sd) 
+distribution = "gamma", mean = si_mean, sd = si_sd) 
 ```
 
 ```{r}

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -412,7 +412,8 @@ si_sd <- params$si_sd
 si_dist <- params$si_dist
 si_cv <- si_sd / si_mean
 si_params <- epiparameter::convert_summary_stats_to_params(
-distribution = "gamma", mean = si_mean, sd = si_sd) 
+  distribution = "gamma", mean = si_mean, sd = si_sd
+)
 ```
 
 ```{r}


### PR DESCRIPTION
Changes in epiparameter usage to update template contents to the latest version of the package:
 

- Changed pathogen to disease on in the params section (both [label and description](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L22-L23)) of the .Rmd to avoid confusion, since `epidist` uses diseases rather than pathogens
- Changed `epidist()` to `epidist_db()` to extract from database ([lines 380-385](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L380-L385))
- Changed `epidist$params` to `as.list(get_parameters(si_epiparameter))` ([line 387](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L387))<- as.list so it can be used with function on [line 406](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L406)
- Changed to `family(epidist)` to extract distribution name ([line 388](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L388))
- Changed [lines 389 and 390](https://github.com/epiverse-trace/episoap/blob/bbf37b92b5e24406e32cad1b90554a9cbd20722d/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd#L389-L390) to extract mean and sd from summary statistics
-  Changed {epiparameter} version on renv
- Changed {epitrix} to {epiparameter} when converting summary statistics to distribution parameters 
- Changed {distcrete} to {epiparameter} when discretising distribution
-  Removed {epitrix} and {distcrete} as they've now been replaced by {epiparameter} functions
- Changed param from "use_epiparameter" to "use_epiparameter_database" now that {epiparameter} is used also when this param = FALSE
- Updated `epiparameter` usage in code chunks to estimate Rt (EpiNow2, R0)