### PR TITLE
Add system dependency instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ episoap::list_templates()
 #> [1] "transmissibility"
 ```
 
+### System dependencies
+
+You may need to install system dependencies:
+
+```
+# macOS
+brew install libsodium
+
+# Linux (Debian based)
+apt install libsodium-dev
+```
+
 ## Related projects
 
 This project has some overlap with other R packages:

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ You may need to install system dependencies:
 
 ```
 # macOS
-brew install libsodium
+brew install libsodium cmake
 
 # Linux (Debian based)
-apt install libsodium-dev
+apt install libsodium-dev cmake
 ```
 
 ## Related projects

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -241,6 +241,18 @@ dark_pink <- "#B45D75"
 theme_set(theme_episoap())
 ```
 
+### System dependencies
+
+You may need to install system dependencies to be able to generate this report:
+
+```sh
+# macOS
+brew install libsodium cmake
+
+# Linux (Debian based)
+apt install libsodium-dev cmake
+```
+
 ##  Importing the data
 
 To illustrate the different analyses, we use real data reporting daily numbers

--- a/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/transmissibility/skeleton/skeleton.Rmd
@@ -241,6 +241,7 @@ dark_pink <- "#B45D75"
 theme_set(theme_episoap())
 ```
 
+<!--
 ### System dependencies
 
 You may need to install system dependencies to be able to generate this report:
@@ -252,6 +253,7 @@ brew install libsodium cmake
 # Linux (Debian based)
 apt install libsodium-dev cmake
 ```
+-->
 
 ##  Importing the data
 


### PR DESCRIPTION
I added a small piece to the README to indicate that there is a need to install a system dependency upon the first run of the template. 

This is not required for installing the package - just for generating the template report.