### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,62 @@
-.Rproj.user
+
+# History files
 .Rhistory
+.Rapp.history
+
+# Session Data files
 .RData
+.RDataTmp
+
+# User-specific files
 .Ruserdata
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md
+
+# R Environment Variables
+.Renviron
+
+# pkgdown site
+docs/
+
+# translation temp files
+po/*~
+
+# RStudio Connect folder
+rsconnect/
+
+# macOS hidden files
+.DS_Store
+
+# ignore development file
+scratch.R
 inst/doc
-docs
+/doc/
+/Meta/
 inst/rmarkdown/templates/*/skeleton/*.html
 inst/rmarkdown/templates/*/skeleton/skeleton_files/
 inst/rmarkdown/templates/*/skeleton/grateful-refs.bib


### PR DESCRIPTION
This very small PR is to update the gitignore file in episoap, which is the only commit included.
I have also kept files which were previously included in gitignore file but aren't in the standard version for Epiverse, namely

- inst/rmarkdown/templates/*/skeleton/*.html
- inst/rmarkdown/templates/*/skeleton/skeleton_files/
- inst/rmarkdown/templates/*/skeleton/grateful-refs.bib

@Bisaloo please let me know if this is correct